### PR TITLE
Allow node sass options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,25 @@ Next, add `styled-jsx-plugin-sass` to the `styled-jsx`'s `plugins` in your babel
 }
 ```
 
+## Node-Sass Options
+
+A subset of [node-sass options](https://github.com/sass/node-sass#options) are supported, namely `precision` and `includePaths`.
+
+```json
+{
+  "plugins": [
+    [
+      "styled-jsx/babel",
+      {
+        "plugins": [
+          ["styled-jsx-plugin-sass", { "includePaths": ["./styles"], "precision": 2 }]
+        ]
+      }
+    ]
+  ]
+}
+```
+
 #### Notes
 
 `styled-jsx-plugin-sass` uses `styled-jsx`'s plugin system which is supported from version 2.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Next, add `styled-jsx-plugin-sass` to the `styled-jsx`'s `plugins` in your babel
 }
 ```
 
-## Node-Sass Options
+## Node-sass options
 
-A subset of [node-sass options](https://github.com/sass/node-sass#options) are supported, namely `precision` and `includePaths`.
+Node-sass can be configured using `sassOptions`. This is useful for setting options such as `includePaths` or `precision`.
 
 ```json
 {
@@ -43,7 +43,13 @@ A subset of [node-sass options](https://github.com/sass/node-sass#options) are s
       "styled-jsx/babel",
       {
         "plugins": [
-          ["styled-jsx-plugin-sass", { "includePaths": ["./styles"], "precision": 2 }]
+          ["styled-jsx-plugin-sass", {
+              "sassOptions": {
+                "includePaths": ["./styles"],
+                "precision": 2
+              }
+            }
+          ]
         ]
       }
     ]

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const sass = require('node-sass')
 
-module.exports = (css, settings = {}) => {
+module.exports = (css, settings) => {
   const cssWithPlaceholders = css
     .replace(/\:\s*%%styled-jsx-expression-(\d+)%%/g, (_, id) =>
       `: styled-jsx-expression-${id}()`
@@ -9,20 +9,9 @@ module.exports = (css, settings = {}) => {
       `/*%%styled-jsx-expression-${id}%%*/`
     )
 
-  // Allow a subset of node-sass options
-  const allowedOptions = ['precision', 'includePaths']
-
-  const options = Object.entries(settings).reduce((p, o) => {
-    const [k, v] = o
-    if (allowedOptions.includes(k)) {
-      p[k] = v
-    }
-    return p
-  }, {})
-
   const preprocessed = sass.renderSync(Object.assign({
     data: cssWithPlaceholders
-  }, options)).css.toString()
+  }, settings.sassOptions)).css.toString()
 
   return preprocessed
     .replace(/\:\s*styled-jsx-expression-(\d+)\(\)/g, (_, id) =>

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-const sass = require('node-sass').renderSync
+const sass = require('node-sass')
 
-module.exports = (css, settings) => {
+module.exports = (css, settings = {}) => {
   const cssWithPlaceholders = css
     .replace(/\:\s*%%styled-jsx-expression-(\d+)%%/g, (_, id) =>
       `: styled-jsx-expression-${id}()`
@@ -9,9 +9,20 @@ module.exports = (css, settings) => {
       `/*%%styled-jsx-expression-${id}%%*/`
     )
 
-  const preprocessed = sass({
+  // Allow a subset of node-sass options
+  const allowedOptions = ['precision', 'includePaths']
+
+  const options = Object.entries(settings).reduce((p, o) => {
+    const [k, v] = o
+    if (allowedOptions.includes(k)) {
+      p[k] = v
+    }
+    return p
+  }, {})
+
+  const preprocessed = sass.renderSync(Object.assign({
     data: cssWithPlaceholders
-  }).css.toString()
+  }, options)).css.toString()
 
   return preprocessed
     .replace(/\:\s*styled-jsx-expression-(\d+)\(\)/g, (_, id) =>

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "mocha": "^4.0.1",
+    "node-sass": "^4.5.3",
     "strip-indent": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,6 @@
   },
   "devDependencies": {
     "mocha": "^4.0.1",
-    "proxyquire": "^1.8.0",
-    "sinon": "^4.0.1",
     "strip-indent": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   },
   "devDependencies": {
     "mocha": "^4.0.1",
+    "proxyquire": "^1.8.0",
+    "sinon": "^4.0.1",
     "strip-indent": "^2.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -20,7 +20,7 @@ describe('styled-jsx-plugin-sass', () => {
 
   it('works with placeholders', () => {
     assert.equal(
-      plugin('p { img { display: block } color: %%styled-jsx-placeholder-0%%; } %%styled-jsx-placeholder-1%%').trim(),
+      plugin('p { img { display: block } color: %%styled-jsx-placeholder-0%%; } %%styled-jsx-placeholder-1%%', {}).trim(),
       cleanup(`
         p {
           color: %%styled-jsx-placeholder-0%%; }

--- a/test.js
+++ b/test.js
@@ -1,21 +1,14 @@
 const assert = require('assert')
 const stripIndent = require('strip-indent')
-const sinon = require('sinon')
-const proxyquire = require('proxyquire')
-const sass = require('node-sass')
+const plugin = require('./')
 
 const cleanup = str => stripIndent(str).trim()
 
 describe('styled-jsx-plugin-sass', () => {
-  let plugin
-
-  before(() => {
-    plugin = require('./')
-  })
 
   it('applies plugins', () => {
     assert.equal(
-      plugin('p { img { display: block} color: color(red a(90%)) }').trim(),
+      plugin('p { img { display: block} color: color(red a(90%)) }', {}).trim(),
       cleanup(`
         p {
           color: color(red a(90%)); }
@@ -27,7 +20,7 @@ describe('styled-jsx-plugin-sass', () => {
 
   it('works with expressions placeholders', () => {
     assert.equal(
-      plugin('p { img { display: block } color: %%styled-jsx-expression-1%%; } %%styled-jsx-expression-1%%').trim(),
+      plugin('p { img { display: block } color: %%styled-jsx-expression-1%%; } %%styled-jsx-expression-1%%', {}).trim(),
       cleanup(`
         p {
           color: %%styled-jsx-expression-1%%; }
@@ -41,7 +34,7 @@ describe('styled-jsx-plugin-sass', () => {
 
   it('works with @import', () => {
     assert.equal(
-      plugin('@import "fixture"; p { color: red }').trim(),
+      plugin('@import "fixture"; p { color: red }', {}).trim(),
       cleanup(`
         div {
           color: red; }
@@ -52,37 +45,17 @@ describe('styled-jsx-plugin-sass', () => {
     )
   })
 
-  describe('node-sass options', () => {
-    let spy
-
-    before(() => {
-      spy = sinon.spy(sass, 'renderSync');
-      plugin = proxyquire('./', {
-        'node-sass': {
-          renderSync: spy
+  it('applies sassOptions', () => {
+    assert.equal(
+      plugin('div { padding: (1 / 3) * 1em }', {
+        sassOptions: {
+          precision: 1
         }
-      })
-    })
-
-    it('allows "precision" to be set', () => {
-      plugin('p { color: red; }', {
-        precision: 2
-      })
-      sinon.assert.calledWithMatch(spy, { precision: 2 })
-    })
-
-    it('it allows "includePaths" to be set', () => {
-      plugin('p { color: red; }', {
-        includePaths: ['./foo']
-      })
-      sinon.assert.calledWithMatch(spy, { includePaths: ['./foo'] })
-    })
-
-    it('does not allow unsupported options', () => {
-      plugin('p { color: red; }', {
-        foo: 'bar'
-      })
-      sinon.assert.neverCalledWithMatch(spy, { foo: 'bar' })
-    })
-  })
+      }).trim(),
+      cleanup(`
+        div {
+          padding: 0.3em; }
+      `)
+    )
+  });
 })


### PR DESCRIPTION
I'd like to propose a change to make it possible to pass `includePaths` and `precision` options to node-sass. For example, I have some SCSS vars and mixins in `./styles` and I'd like to make it easier to resolve these.


With this change I can configure as follows:

~~`["styled-jsx-plugin-sass", { "includePaths": ["./styles"] }]`~~

```
["styled-jsx-plugin-sass", {
    "sassOptions": {
      "includePaths": ["./styles"]
    }
  }
]
```

And then do something like:

```
<style jsx>{`
  @import "colors";
  div {
    background: $color-red;
  }
`}</style>
```

~~I allowed a subset of options because it _probably_ doesn't make sense to allow all of the node-sass options to be applied.~~