### PR TITLE
Replace styled-jsx-placeholder patterns

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,11 @@ const sass = require('node-sass').renderSync
 
 module.exports = (css, settings) => {
   const cssWithPlaceholders = css
-    .replace(/\:\s*%%styled-jsx-expression-(\d+)%%/g, (_, id) =>
-      `: styled-jsx-expression-${id}()`
+    .replace(/\:\s*%%styled-jsx-(expression|placeholder)-(\d+)%%/g, (_, p, id) =>
+      `: styled-jsx-${p}-${id}()`
     )
-    .replace(/%%styled-jsx-expression-(\d+)%%/g, (_, id) =>
-      `/*%%styled-jsx-expression-${id}%%*/`
+    .replace(/%%styled-jsx-(expression|placeholder)-(\d+)%%/g, (_, p, id) =>
+      `/*%%styled-jsx-${p}-${id}%%*/`
     )
 
   const preprocessed = sass({
@@ -14,10 +14,10 @@ module.exports = (css, settings) => {
   }).css.toString()
 
   return preprocessed
-    .replace(/\:\s*styled-jsx-expression-(\d+)\(\)/g, (_, id) =>
-      `: %%styled-jsx-expression-${id}%%`
+    .replace(/\:\s*styled-jsx-(expression|placeholder)-(\d+)\(\)/g, (_, p, id) =>
+      `: %%styled-jsx-${p}-${id}%%`
     )
-    .replace(/\/\*%%styled-jsx-expression-(\d+)%%\*\//g, (_, id) =>
-      `%%styled-jsx-expression-${id}%%`
+    .replace(/\/\*%%styled-jsx-(expression|placeholder)-(\d+)%%\*\//g, (_, p, id) =>
+      `%%styled-jsx-${p}-${id}%%`
     )
 }

--- a/index.js
+++ b/index.js
@@ -2,11 +2,11 @@ const sass = require('node-sass').renderSync
 
 module.exports = (css, settings) => {
   const cssWithPlaceholders = css
-    .replace(/\:\s*%%styled-jsx-(expression|placeholder)-(\d+)%%/g, (_, p, id) =>
-      `: styled-jsx-${p}-${id}()`
+    .replace(/\:\s*%%styled-jsx-placeholder-(\d+)%%/g, (_, id) =>
+      `: styled-jsx-placeholder-${id}()`
     )
-    .replace(/%%styled-jsx-(expression|placeholder)-(\d+)%%/g, (_, p, id) =>
-      `/*%%styled-jsx-${p}-${id}%%*/`
+    .replace(/%%styled-jsx-placeholder-(\d+)%%/g, (_, id) =>
+      `/*%%styled-jsx-placeholder-${id}%%*/`
     )
 
   const preprocessed = sass({
@@ -14,10 +14,10 @@ module.exports = (css, settings) => {
   }).css.toString()
 
   return preprocessed
-    .replace(/\:\s*styled-jsx-(expression|placeholder)-(\d+)\(\)/g, (_, p, id) =>
-      `: %%styled-jsx-${p}-${id}%%`
+    .replace(/\:\s*styled-jsx-placeholder-(\d+)\(\)/g, (_, id) =>
+      `: %%styled-jsx-placeholder-${id}%%`
     )
-    .replace(/\/\*%%styled-jsx-(expression|placeholder)-(\d+)%%\*\//g, (_, p, id) =>
-      `%%styled-jsx-${p}-${id}%%`
+    .replace(/\/\*%%styled-jsx-placeholder-(\d+)%%\*\//g, (_, id) =>
+      `%%styled-jsx-placeholder-${id}%%`
     )
 }

--- a/test.js
+++ b/test.js
@@ -17,21 +17,7 @@ describe('styled-jsx-plugin-sass', () => {
     )
   })
 
-  it('works with "styled-jsx-expression" placeholders', () => {
-    assert.equal(
-      plugin('p { img { display: block } color: %%styled-jsx-expression-0%%; } %%styled-jsx-expression-1%%').trim(),
-      cleanup(`
-        p {
-          color: %%styled-jsx-expression-0%%; }
-          p img {
-            display: block; }
-
-        %%styled-jsx-expression-1%%
-      `)
-    )
-  })
-
-  it('works with "styled-jsx-placeholder" placeholders', () => {
+  it('works with placeholders', () => {
     assert.equal(
       plugin('p { img { display: block } color: %%styled-jsx-placeholder-0%%; } %%styled-jsx-placeholder-1%%').trim(),
       cleanup(`

--- a/test.js
+++ b/test.js
@@ -17,16 +17,30 @@ describe('styled-jsx-plugin-sass', () => {
     )
   })
 
-  it('works with expressions placeholders', () => {
+  it('works with "styled-jsx-expression" placeholders', () => {
     assert.equal(
-      plugin('p { img { display: block } color: %%styled-jsx-expression-1%%; } %%styled-jsx-expression-1%%').trim(),
+      plugin('p { img { display: block } color: %%styled-jsx-expression-0%%; } %%styled-jsx-expression-1%%').trim(),
       cleanup(`
         p {
-          color: %%styled-jsx-expression-1%%; }
+          color: %%styled-jsx-expression-0%%; }
           p img {
             display: block; }
 
         %%styled-jsx-expression-1%%
+      `)
+    )
+  })
+
+  it('works with "styled-jsx-placeholder" placeholders', () => {
+    assert.equal(
+      plugin('p { img { display: block } color: %%styled-jsx-placeholder-0%%; } %%styled-jsx-placeholder-1%%').trim(),
+      cleanup(`
+        p {
+          color: %%styled-jsx-placeholder-0%%; }
+          p img {
+            display: block; }
+
+        %%styled-jsx-placeholder-1%%
       `)
     )
   })


### PR DESCRIPTION
This PR adds support for handling `styled-jsx-placeholder` patterns. See https://github.com/giuseppeg/styled-jsx-plugin-sass/issues/1 for details.