### PR TITLE
match comma-separated placeholders

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const sass = require('node-sass')
 
 module.exports = (css, settings) => {
   const cssWithPlaceholders = css
-    .replace(/%%styled-jsx-placeholder-(\d+)%%(\w*\s*[);{])/g, (_, id, p1) =>
+    .replace(/%%styled-jsx-placeholder-(\d+)%%(\w*\s*[),;{])/g, (_, id, p1) =>
       `styled-jsx-placeholder-${id}-${p1}`
     )
     .replace(/%%styled-jsx-placeholder-(\d+)%%/g, (_, id) =>
@@ -14,7 +14,7 @@ module.exports = (css, settings) => {
   }, settings.sassOptions)).css.toString()
 
   return preprocessed
-    .replace(/styled-jsx-placeholder-(\d+)-(\w*\s*[);{])/g, (_, id, p1) =>
+    .replace(/styled-jsx-placeholder-(\d+)-(\w*\s*[),;{])/g, (_, id, p1) =>
       `%%styled-jsx-placeholder-${id}%%${p1}`
     )
     .replace(/\/\*%%styled-jsx-placeholder-(\d+)%%\*\//g, (_, id) =>

--- a/test.js
+++ b/test.js
@@ -28,6 +28,16 @@ describe('styled-jsx-plugin-sass', () => {
     )
   })
 
+  it("works with placeholders in css functions", () => {
+    assert.equal(
+      plugin('div { grid-template-columns: repeat(%%styled-jsx-placeholder-0%%, calc(%%styled-jsx-placeholder-1%%% - %%styled-jsx-placeholder-2%%px)); }', {}).trim(),
+      cleanup(`
+        div {
+          grid-template-columns: repeat(%%styled-jsx-placeholder-0%%, calc(%%styled-jsx-placeholder-1%%% - %%styled-jsx-placeholder-2%%px)); }
+      `)
+    )
+  })
+
   it('works with placeholders', () => {
     assert.equal(
       plugin(`


### PR DESCRIPTION
specifically looking to support template expressions in comma-separated css functions like 

```css
grid-template-columns: repeat(${columnCount}, calc(${100 / columnCount}% - ${16 * (columnCount - 1) / columnCount}px));
```

currently `node-sass` gives the following error:

```
Invalid CSS after "...aceholder-0%%*/": expected expression (e.g. 1px, bold), was ", calc(/*%%styled-j"
```

but matching commas as an indicator for css values seems to do the trick.