### PR TITLE
Fix relative imports.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,11 @@ module.exports = (css, settings) => {
   const optionData = settings.sassOptions && settings.sassOptions.data || "";
   const data = optionData + "\n" + cssWithPlaceholders;
 
+  const file = settings.babel && settings.babel.filename;
+
   const preprocessed = sass.renderSync(
     Object.assign(
-      {},
+      {file},
       settings.sassOptions,
       { data }
     )).css.toString()

--- a/test.js
+++ b/test.js
@@ -122,9 +122,6 @@ describe('styled-jsx-plugin-sass', () => {
 
     assert.equal(
       plugin(file.toString(), {
-        sassOptions: {
-          includePaths: [path.join(__dirname, 'fixtures')]
-        },
         babel: { filename }
       }).trim(),
       cleanup(`


### PR DESCRIPTION
**UPDATE:** Only discussing the fixes to relative imports here. See #31 for the percent char issue fix as a separate PR.

The fix for `includePaths` included in `v1.0.0` breaks all relative imports.

While investigating a proper fix, I also noticed that one of the existing tests was failing in `node-sass@4.11` (but worked fine in `node-sass@4.10`). For some reason, placeholders immediately followed by a `%` char were causing syntax errors.

I fixed the `%` char problem in the first commit, and relative imports in the second. Both commit comments contain more detailed explanations.

The relative `@import` fix should definitely be incorporated.

I suspect the other might actually just be a `node-sass` bug (I don't know enough about the syntax to say for sure). That said, It's a 4 line fix that's easy enough to back out later.